### PR TITLE
⚡️ Get all users' info together

### DIFF
--- a/src/pages/TeamJoinPage.tsx
+++ b/src/pages/TeamJoinPage.tsx
@@ -66,6 +66,8 @@ const TeamJoinPage: React.FC<
     getSelfTeam,
     totalTeams,
     getTeamNum,
+    contestId,
+    getContestId,
     error,
     fetching
   } = props;
@@ -77,15 +79,15 @@ const TeamJoinPage: React.FC<
   const [activeRow, setActiveRow] = useState("");
   const [exporting, setExporting] = useState(false);
 
-  // useEffect(() => {
-  //   getContestId("电设", 2019);
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
-
   useEffect(() => {
-    getSelfTeam("电设", 2019);
+    if (contestId) {
+      getSelfTeam("电设", 2019);
+      getTeamNum("电设", 2019);
+    } else {
+      getContestId("电设", 2019);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [contestId]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -97,15 +99,13 @@ const TeamJoinPage: React.FC<
         pageNumber * pageSize
       );
     };
-
-    fetchData();
+    if (contestId) {
+      fetchData();
+    } else {
+      getContestId("电设", 2019);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageNumber, pageSize]);
-
-  useEffect(() => {
-    getTeamNum("电设", 2019);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [contestId, pageNumber, pageSize]);
 
   useEffect(() => {
     if (error) {

--- a/src/redux/actions/teams.ts
+++ b/src/redux/actions/teams.ts
@@ -58,23 +58,15 @@ export function getTeams(
         teams = await api.getTeams(self, getState().teams.contestId!, token);
       }
 
-      const leaders = teams.map(team => {
-        return team.leader;
-      });
       const players = teams.reduce(
         (data: number[], team) => data.concat(team.members),
         []
       );
 
-      const leadersInfo = await api.getUserInfos(leaders, token);
       const playersInfo = await api.getUserInfos(players, token);
 
-      const leaderInfoPair: { [key: number]: IUser } = {};
       const playerInfoPair: { [key: number]: IUser } = {};
 
-      leadersInfo.forEach(leader => {
-        leaderInfoPair[leader.id] = leader;
-      });
       playersInfo.forEach(player => {
         playerInfoPair[player.id] = player;
       });
@@ -84,7 +76,7 @@ export function getTeams(
           const membersInfo = team.members.map(member => {
             return playerInfoPair[member];
           });
-          const leaderInfo = leaderInfoPair[team.leader];
+          const leaderInfo = playersInfo[team.leader];
           return {
             ...team,
             membersInfo: membersInfo,

--- a/src/redux/actions/teams.ts
+++ b/src/redux/actions/teams.ts
@@ -21,7 +21,7 @@ import {
   GET_CONTEST_ID_SUCCESS,
   GET_CONTEST_ID_FAILURE
 } from "../types/constants";
-import { ITeam } from "../types/state";
+import { ITeam, IUser } from "../types/state";
 
 export const getTeamsAction = createAsyncAction(
   GET_TEAMS_REQUEST,
@@ -58,10 +58,33 @@ export function getTeams(
         teams = await api.getTeams(self, getState().teams.contestId!, token);
       }
 
+      const leaders = teams.map(team => {
+        return team.leader;
+      });
+      const players = teams.reduce(
+        (data: number[], team) => data.concat(team.members),
+        []
+      );
+
+      const leadersInfo = await api.getUserInfos(leaders, token);
+      const playersInfo = await api.getUserInfos(players, token);
+
+      const leaderInfoPair: { [key: number]: IUser } = {};
+      const playerInfoPair: { [key: number]: IUser } = {};
+
+      leadersInfo.forEach(leader => {
+        leaderInfoPair[leader.id] = leader;
+      });
+      playersInfo.forEach(player => {
+        playerInfoPair[player.id] = player;
+      });
+
       teams = await Promise.all(
         teams.map(async team => {
-          const membersInfo = await api.getUserInfos(team.members, token);
-          const leaderInfo = membersInfo[0];
+          const membersInfo = team.members.map(member => {
+            return playerInfoPair[member];
+          });
+          const leaderInfo = leaderInfoPair[team.leader];
           return {
             ...team,
             membersInfo: membersInfo,
@@ -126,9 +149,7 @@ export function getSelfTeam(
       if (team.length) {
         const selfTeam = team[0];
         selfTeam.leaderInfo = await api.getUserInfo(selfTeam.leader, token);
-        selfTeam.membersInfo = await Promise.all(
-          selfTeam.members.map(id => api.getUserInfo(id, token))
-        );
+        selfTeam.membersInfo = await api.getUserInfos(selfTeam.members, token);
 
         dispatch(getSelfTeamAction.success(selfTeam));
       } else {


### PR DESCRIPTION
将加入页面所有待显示队伍的成员一起获取，减少请求数

```
POST /v1/users/login 200 75.250 ms - 641
GET /v1/contests?type=%E7%94%B5%E8%AE%BE&year=2019 304 2.003 ms - -
GET /v1/contests?type=%E7%94%B5%E8%AE%BE&year=2019 304 2.761 ms - -
GET /v1/teams?self=true&contestId=4 304 3.788 ms - -
GET /v1/contests/4 304 12.740 ms - -
GET /v1/teams?self=false&contestId=4&begin=0&end=10 304 15.030 ms - -
GET /v1/users/2000000000 304 3.653 ms - -
POST /v1/users/details 200 7.023 ms - 1073
POST /v1/users/details 200 10.001 ms - 615
POST /v1/users/details 200 7.296 ms - 1672
```

最后的三个获取用户信息的请求分别是请求“所有队长”“所有选手”“自己队伍的成员”