### PR TITLE
feat(mentor,cos): 增添谈话记录提交功能

### DIFF
--- a/src/api/info_mentor.graphql
+++ b/src/api/info_mentor.graphql
@@ -21,6 +21,7 @@ query GetMentorApplications($_id: String!) {
     }
     statement
     status
+    chat_status
     created_at
     updated_at
   }
@@ -74,6 +75,17 @@ mutation UpdateMentorApplicationStatus($id: uuid!, $status: String!) {
   update_mentor_application(
     where: { id: { _eq: $id } }
     _set: { status: $status }
+  ) {
+    returning {
+      id
+    }
+  }
+}
+
+mutation UpdateMentorApplicationChatStatus($id: uuid!, $chat_status: Boolean!){
+  update_mentor_application(
+    where: { id: { _eq: $id } }
+    _set: { chat_status: $chat_status }
   ) {
     returning {
       id

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -2164,6 +2164,7 @@ export interface GetMentorApplications_mentor_application {
    * approved | submitted
    */
   status: string;
+  chat_status: boolean;
   created_at: any;
   updated_at: any;
 }
@@ -2324,6 +2325,40 @@ export interface UpdateMentorApplicationStatus {
 export interface UpdateMentorApplicationStatusVariables {
   id: any;
   status: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateMentorApplicationChatStatus
+// ====================================================
+
+export interface UpdateMentorApplicationChatStatus_update_mentor_application_returning {
+  __typename: "mentor_application";
+  id: any;
+}
+
+export interface UpdateMentorApplicationChatStatus_update_mentor_application {
+  __typename: "mentor_application_mutation_response";
+  /**
+   * data from the rows affected by the mutation
+   */
+  returning: UpdateMentorApplicationChatStatus_update_mentor_application_returning[];
+}
+
+export interface UpdateMentorApplicationChatStatus {
+  /**
+   * update data of the table: "mentor_application"
+   */
+  update_mentor_application: UpdateMentorApplicationChatStatus_update_mentor_application | null;
+}
+
+export interface UpdateMentorApplicationChatStatusVariables {
+  id: any;
+  chat_status: boolean;
 }
 
 /* tslint:disable */

--- a/src/helpers/cos.ts
+++ b/src/helpers/cos.ts
@@ -6,7 +6,7 @@ let team_id = "-1";
 const cos = new COS({
   getAuthorization: async (options: object, callback: Function) => {
     try {
-      const response = await axios.get("/static", {
+      const response = await axios.get("/static/team_code", {
         params: {
           team_id: team_id
         }

--- a/src/helpers/cos_new.ts
+++ b/src/helpers/cos_new.ts
@@ -1,0 +1,89 @@
+/*
+cos.ts中的写法与team耦合过于紧密，不便于添加新类型文件的上传下载
+在添加新生导师的谈话记录提交功能时重新改写此页，但保留原页功能，后续合并
+上传的逻辑为：
+文件内容, 上传路径, 鉴权方式(路由), 鉴权所需参数(一个键值表对象)
+下载的逻辑为：
+下载路径，鉴权路由，鉴权所需参数
+*/
+import COS from "cos-js-sdk-v5";
+import axios from 'axios';
+
+let path = '';
+let params = {};
+let bucket = 'eesast-1255334966';
+let region = 'ap-beijing';
+const cos = new COS({ //getAuthorization会在每次使用cos时调用
+  getAuthorization: async (options: object, callback: Function) => {
+    try {
+      const response = await axios.get(`/static/${path}`, {
+        params: params
+      });
+      if (response.status === 200) {
+        if (!response.data.credentials) throw (Error("Credentials invalid!"));
+        callback({
+          TmpSecretId: response.data.credentials.tmpSecretId,
+          TmpSecretKey: response.data.credentials.tmpSecretKey,
+          SecurityToken: response.data.credentials.sessionToken,
+          StartTime: response.data.startTime,
+          ExpiredTime: response.data.expiredTime,
+        });
+      }
+      else throw (Error(response.data));
+    } catch (err) {
+      return console.log(err);
+    }
+  }
+});
+
+export const uploadFile = (file: any, url: string, _path: string, _params: object) => {
+  path = _path;
+  params = _params;
+  return cos.uploadFile({
+    Bucket: bucket,
+    Region: region,
+    Key: url,
+    Body: file,
+    SliceSize: 1024 * 1024 * 5
+  });
+}
+
+const downloadByUrl = (url: string) => {
+  var element = document.createElement('a');
+  element.href = url;
+  element.style.display = 'none';
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}
+
+export const downloadFile = (url: string, _path: string, _params: object) => {
+  path = _path;
+  params = _params;
+  return new Promise ((resolve, reject) => {
+    cos.getObjectUrl({
+      Bucket: bucket,
+      Region: region,
+      Key: url,
+    }, (err, data) => {
+      if (err) return reject(err);
+      downloadByUrl(data.Url + (data.Url.indexOf('?') > -1 ? '&' : '?') + 'response-content-disposition=attachment;')
+      return resolve(data);
+    });
+  });
+}
+
+export const listFile = (prefix: string, _path: string, _params: object) => {
+  path = _path;
+  params = _params;
+  return new Promise <COS.CosObject[]>((resolve, reject) => {
+    cos.getBucket({
+      Bucket: bucket,
+      Region: region,
+      Prefix: prefix,
+    }, (err, data) => {
+      if (err || !data) return reject(err);
+      return resolve(data.Contents);
+    });
+  })
+}


### PR DESCRIPTION
- hasura中添加了chat_status项
- 添加了提交和下载按钮
- 新增了cos_new.ts作为权限申请方式的改进写法
- 还需要做的：
    1. 目前的提交不会删除桶内之前的文件，但同名会覆盖，可以考虑在重复提交时加个询问Modal。且删除申请时存储桶没删。
    2. 合并 cos.ts 与 cos_new.ts
    3. 优化一下界面，可以考虑把删除申请按钮提出来放到整个表的右下角