### PR TITLE
fix(mentor): 隐藏导师列表中的未使用导师

### DIFF
--- a/src/pages/InfoSite/MentorApplicationPage.tsx
+++ b/src/pages/InfoSite/MentorApplicationPage.tsx
@@ -1178,7 +1178,7 @@ const MentorApplicationPage = () => {
             rowKey="_id"
             loading={mentorListLoading}
             dataSource={mentorList?.user_by_role.filter(
-              (item) => item.user?.mentor_available?.available !== false
+              (item) => item.user?.mentor_available?.available
             )}
             columns={mentorListColumnsForStudents}
           />


### PR DESCRIPTION
mentor_available变量是通过insert on conflict，也就是upsert（插入或更新）的方式维护的，有的导师数据在hasura数据库中是自动生成的，该变量为null，而在js中等号判断时 null!=false，导致导师显示在列表中但无法申请，此处修改为直接用 mentor_available 作为条件判断。