### PR TITLE
fix(Login&Profile): 暂时关闭reCAPTCHA验证

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Form,
   Input,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -21,14 +21,14 @@ import { Location } from "history";
 import styled from "styled-components";
 import Center from "../components/Center";
 import axios, { AxiosError } from "axios";
-import ReCAPTCHA from "react-google-recaptcha";
+// import ReCAPTCHA from "react-google-recaptcha";
 import IsEmail from "isemail";
 import Picture from "../components/Picture";
 import { validatePassword } from "../helpers/validate";
 
-(window as any).recaptchaOptions = {
-  useRecaptchaNet: true,
-};
+// (window as any).recaptchaOptions = {
+//   useRecaptchaNet: true,
+// };
 
 const Background = styled.div`
   height: calc(100vh - 67px);
@@ -118,7 +118,7 @@ const LoginPage: React.FC = () => {
         } else {
           message.error("未知错误");
         }
-        reCaptchaRef.current?.reset();
+        // reCaptchaRef.current?.reset();
       }
     } else if (resetToken) {
       try {
@@ -153,7 +153,7 @@ const LoginPage: React.FC = () => {
         } else {
           message.error("未知错误");
         }
-        reCaptchaRef.current?.reset();
+        // reCaptchaRef.current?.reset();
       }
     } else if (register) {
       try {
@@ -172,7 +172,7 @@ const LoginPage: React.FC = () => {
         } else {
           message.error("未知错误");
         }
-        reCaptchaRef.current?.reset();
+        // reCaptchaRef.current?.reset();
       }
     } else {
       try {
@@ -210,7 +210,7 @@ const LoginPage: React.FC = () => {
     setLoading(false);
   };
 
-  const reCaptchaRef = useRef<ReCAPTCHA>(null);
+  // const reCaptchaRef = useRef<ReCAPTCHA>(null);
 
   const [form] = Form.useForm();
 
@@ -290,15 +290,17 @@ const LoginPage: React.FC = () => {
                     autoFocus
                   />
                 </Form.Item>
-                <Form.Item
-                  name="recaptcha"
-                  rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
-                >
-                  <ReCAPTCHA
-                    ref={reCaptchaRef}
-                    sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
-                  />
-                </Form.Item>
+                {
+                // <Form.Item
+                //   name="recaptcha"
+                //   rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
+                // >
+                //   <ReCAPTCHA
+                //     ref={reCaptchaRef}
+                //     sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
+                //   />
+                // </Form.Item>
+                }
                 <Form.Item>
                   <Button type="primary" htmlType="submit" loading={loading}>
                     发送验证邮件
@@ -413,15 +415,17 @@ const LoginPage: React.FC = () => {
                     autoFocus
                   />
                 </Form.Item>
-                <Form.Item
-                  name="recaptcha"
-                  rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
-                >
-                  <ReCAPTCHA
-                    ref={reCaptchaRef}
-                    sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
-                  />
-                </Form.Item>
+                {
+                // <Form.Item
+                //   name="recaptcha"
+                //   rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
+                // >
+                //   <ReCAPTCHA
+                //     ref={reCaptchaRef}
+                //     sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
+                //   />
+                // </Form.Item>
+                }
                 <Form.Item>
                   <Button type="primary" htmlType="submit" loading={loading}>
                     发送重置邮件
@@ -522,15 +526,17 @@ const LoginPage: React.FC = () => {
                     placeholder="确认密码"
                   />
                 </Form.Item>
-                <Form.Item
-                  name="recaptcha"
-                  rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
-                >
-                  <ReCAPTCHA
-                    ref={reCaptchaRef}
-                    sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
-                  />
-                </Form.Item>
+                {
+                // <Form.Item
+                //   name="recaptcha"
+                //   rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
+                // >
+                //   <ReCAPTCHA
+                //     ref={reCaptchaRef}
+                //     sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
+                //   />
+                // </Form.Item>
+                }
                 <Form.Item>
                   <Button type="primary" htmlType="submit" loading={loading}>
                     注册

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -21,7 +21,7 @@ import {
 import Loading from "../components/Loading";
 import axios, { AxiosError } from "axios";
 import IsEmail from "isemail";
-import ReCAPTCHA from "react-google-recaptcha";
+// import ReCAPTCHA from "react-google-recaptcha";
 import { getUserInfo } from "../helpers/auth";
 import { validateClass, validatePassword } from "../helpers/validate";
 
@@ -140,7 +140,7 @@ const ProfilePage: React.FC = () => {
   const [verifyLoading, setVerifyLoading] = useState(false);
   const [passwordUpdating, setPasswordUpdating] = useState(false);
   const [userDeleting, setUserDeleting] = useState(false);
-  const reCaptchaRef = useRef<ReCAPTCHA>(null);
+  // const reCaptchaRef = useRef<ReCAPTCHA>(null);
   const [form] = Form.useForm();
 
   if (loading) {
@@ -176,7 +176,7 @@ const ProfilePage: React.FC = () => {
       } else {
         message.error("未知错误");
       }
-      reCaptchaRef.current?.reset();
+      // reCaptchaRef.current?.reset();
       setVerifyLoading(false);
     }
   };
@@ -440,15 +440,17 @@ const ProfilePage: React.FC = () => {
               autoFocus
             />
           </Form.Item>
-          <Form.Item
-            name="recaptcha"
-            rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
-          >
-            <ReCAPTCHA
-              ref={reCaptchaRef}
-              sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
-            />
-          </Form.Item>
+          {
+          // <Form.Item
+          //   name="recaptcha"
+          //   rules={[{ required: true, message: "请通过 reCAPTCHA 验证" }]}
+          // >
+          //   <ReCAPTCHA
+          //     ref={reCaptchaRef}
+          //     sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY!}
+          //   />
+          // </Form.Item>
+          }
         </Form>
       </Modal>
     </Container>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import { message, Form, Input, Button, Alert, Modal } from "antd";
 import { useQuery, useMutation } from "@apollo/client";
 import styled from "styled-components";


### PR DESCRIPTION
很奇怪，校园网下reCAPTCHA验证框显示不出来，网络错误。
挂梯子后可以使用，有的换成手机热点也可以使用（但有的好像又不行）。
新生导师阶段有许多人要注册验证，为了方便暂时关闭reCAPTCHA。