### PR TITLE
fix(Profile): 更新信息不改密码的bug

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -184,8 +184,6 @@ const ProfilePage: React.FC = () => {
   const onFinish = async (values: any) => {
     const { password, registeredEmail, ...rest } = values;
 
-    setPasswordUpdating(true);
-
     if (userInfo?.role === "teacher") {
       updateUserForTeacher({
         variables: {
@@ -203,6 +201,7 @@ const ProfilePage: React.FC = () => {
     }
 
     if (password) {
+      setPasswordUpdating(true);
       try {
         await axios.put("/users", {
           password,


### PR DESCRIPTION
更新信息不改密码更新按钮一直转，置了true没置回去