### PR TITLE
fix&refact: COS access path

### DIFF
--- a/src/components/AuthRoute.tsx
+++ b/src/components/AuthRoute.tsx
@@ -17,12 +17,11 @@ const AuthRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
       variables: { _id: userInfo?._id! },
     }
   );
-
   return (
     <Route {...rest}>
       {loading ? (
         <Loading />
-      ) : !error && data?.user[0]._id ? (
+      ) : !error && data?.user[0]?._id ? (
         children
       ) : (
         <Redirect

--- a/src/helpers/cos.ts
+++ b/src/helpers/cos.ts
@@ -1,25 +1,13 @@
-/*
-path为鉴权路由，params为所需参数(一个键值对象)，发送给后端(api/src/routes/static)进行权限申请
-目前的路由：
-- team_code: THUAI6选手代码
-  参数为 team_id
-- chat_record: 新生导师谈话记录
-  参数为 application_id
-- ''(默认空): 全局权限 
-*/
 import COS from "cos-js-sdk-v5";
 import axios from 'axios';
 
-let path = '';
-let params = {};
 let bucket = 'eesast-1255334966';
 let region = 'ap-beijing';
+let path = '';
 const cos = new COS({ //getAuthorization会在每次使用cos时调用
-  getAuthorization: async (options: object, callback: Function) => {
+  getAuthorization: async (options: COS.GetAuthorizationOptions, callback: Function) => {
     try {
-      const response = await axios.get(`/static/${path}`, {
-        params: params
-      });
+      const response = await axios.get(`/static/${options.Key||path}`);
       if (response.status === 200) {
         if (!response.data.credentials) throw (Error("Credentials invalid!"));
         callback({
@@ -37,9 +25,7 @@ const cos = new COS({ //getAuthorization会在每次使用cos时调用
   }
 });
 
-export const uploadFile = (file: any, url: string, _path: string = "", _params: object = {}) => {
-  path = _path;
-  params = _params;
+export const uploadFile = (file: any, url: string) => {
   return cos.uploadFile({
     Bucket: bucket,
     Region: region,
@@ -58,9 +44,7 @@ const downloadByUrl = (url: string) => {
   document.body.removeChild(element);
 }
 
-export const downloadFile = (url: string, _path: string = "", _params: object = {}) => {
-  path = _path;
-  params = _params;
+export const downloadFile = (url: string) => {
   return new Promise ((resolve, reject) => {
     cos.getObjectUrl({
       Bucket: bucket,
@@ -74,9 +58,7 @@ export const downloadFile = (url: string, _path: string = "", _params: object = 
   });
 }
 
-export const deleteFile = (url: string, _path: string = "", _params: object = {}) => {
-  path = _path;
-  params = _params;
+export const deleteFile = (url: string) => {
   return cos.deleteObject({
     Bucket: bucket,
     Region: region,
@@ -84,9 +66,7 @@ export const deleteFile = (url: string, _path: string = "", _params: object = {}
   });
 }
 
-export const existFile = (url: string, _path: string = "", _params: object = {}) => {
-  path = _path;
-  params = _params;
+export const existFile = (url: string) => {
   return new Promise <boolean>((resolve, reject) => {
     cos.headObject({
       Bucket: bucket,
@@ -104,9 +84,8 @@ export const existFile = (url: string, _path: string = "", _params: object = {})
   })
 }
 
-export const listFile = (prefix: string, _path: string = "", _params: object = {}) => {
-  path = _path;
-  params = _params;
+export const listFile = (prefix: string) => {
+  path = prefix;
   return new Promise <COS.CosObject[]>((resolve, reject) => {
     cos.getBucket({
       Bucket: bucket,

--- a/src/pages/ContestSite/CodePage.tsx
+++ b/src/pages/ContestSite/CodePage.tsx
@@ -349,6 +349,7 @@ const CodePage: React.FC = () => {
           }
           try {
             await axios.post("code/compile", {
+              contest_id: Contest_id,
               team_id: teamid,
             });
             message.info("已开始编译。编译需要一段时间，请稍后刷新以查看。");
@@ -395,13 +396,13 @@ const CodePage: React.FC = () => {
         const lang = e.file.name.split(".").slice(-1, ).join('');
         try {
           if (lang === "cpp") {
-            const url = `THUAI6/${teamid}/player${codeRole}.cpp`;
-            const result = await uploadFile(e.file, url, "team_code", {team_id: teamid});
+            const url = `code/${Contest_id}/${teamid}/player${codeRole}.cpp`;
+            const result = await uploadFile(e.file, url);
             e.onSuccess(result, e.file);
             handleCodeChange(url, codeRole, lang);
           } else if (lang === "py") {
-            const url = `THUAI6/${teamid}/player${codeRole}.py`;
-            const result = await uploadFile(e.file, url, "team_code", {team_id: teamid});
+            const url = `code/${Contest_id}/${teamid}/player${codeRole}.py`;
+            const result = await uploadFile(e.file, url);
             e.onSuccess(result, e.file);
             handleCodeChange(url, codeRole, lang);
           } else {
@@ -437,9 +438,9 @@ const CodePage: React.FC = () => {
         try {
           if (file.response?.status === 200) {
             if (lang === "cpp") {
-              await deleteFile(`/THUAI6/${teamid}/player${codeRole}.cpp`, "team_code", {team_id: teamid});
+              await deleteFile(`code/${Contest_id}/${teamid}/player${codeRole}.cpp`);
             } else if (lang === "py") {
-              await deleteFile(`/THUAI6/${teamid}/player${codeRole}.py`, "team_code", {team_id: teamid});
+              await deleteFile(`code/${Contest_id}/${teamid}/player${codeRole}.py`);
             }
           }
         } catch (err) {
@@ -449,28 +450,28 @@ const CodePage: React.FC = () => {
 
     const handleDownload = async () => {
         try {
-          const cpp_exist = await existFile(`THUAI6/${teamid}/player${codeRole}.cpp`, "team_code", {team_id: teamid});
-          const py_exist = await existFile(`THUAI6/${teamid}/player${codeRole}.py`, "team_code", {team_id: teamid});
+          const cpp_exist = await existFile(`code/${Contest_id}/${teamid}/player${codeRole}.cpp`);
+          const py_exist = await existFile(`code/${Contest_id}/${teamid}/player${codeRole}.py`);
           if ((cpp_exist && py_exist) || (!cpp_exist && !py_exist)) {
             throw(Error("File error"));
           }
           if (cpp_exist) {
             const codefile = {
               filename: `player${codeRole}.cpp`,
-              url: `/THUAI6/${teamid}/player${codeRole}.cpp`
+              url: `code/${Contest_id}/${teamid}/player${codeRole}.cpp`
             }
             message.info("开始下载:" + codefile.filename);
-            downloadFile(codefile.url, "team_code", {team_id: teamid}).catch(e => {
+            downloadFile(codefile.url).catch(e => {
               message.error("下载失败");
             })
           }
           else if (py_exist) {
             const codefile = {
               filename: `player${codeRole}.py`,
-              url: `/THUAI6/${teamid}/player${codeRole}.py`
+              url: `code/${Contest_id}/${teamid}/player${codeRole}.py`
             }
             message.info("开始下载:" + codefile.filename);
-            downloadFile(codefile.url, "team_code", {team_id: teamid}).catch(e => {
+            downloadFile(codefile.url).catch(e => {
               message.error("下载失败");
             })
           }

--- a/src/pages/ContestSite/ResourcePage.tsx
+++ b/src/pages/ContestSite/ResourcePage.tsx
@@ -150,7 +150,7 @@ const ResourcePage: React.FC = () => {
     const values = form.getFieldsValue();
     const files = fileList.map((f) => ({
       filename: f.name,
-      url: "/contest_upload/" + f.name,
+      url: `contest_upload/${Contest_id}/${f.name}`,
     }));
 
     if (editingNotice) {
@@ -184,7 +184,7 @@ const ResourcePage: React.FC = () => {
 
   const handleUpload = async (e: RcCustomRequestOptions) => {
     try {
-      const url = "contest_upload/" + e.file.name;
+      const url = `contest_upload/${Contest_id}/${e.file.name}`;
       const result = await uploadFile(e.file, url);
       e.onSuccess(result, e.file);
     } catch (err) {
@@ -216,7 +216,7 @@ const ResourcePage: React.FC = () => {
       // }
       // else throw (Error("error"));
       if (file.response?.status === 200) {
-        await deleteFile("contest_upload/" + file.name);
+        await deleteFile(`contest_upload/${Contest_id}/${file.name}`);
       }
       // refetchNotices();
     } catch (err) {
@@ -305,7 +305,7 @@ const ResourcePage: React.FC = () => {
         onCancel={() => {
           const files = fileList.map((f) => ({
             filename: f.name,
-            url: "/contest_upload/" + f.name,
+            url: `contest_upload/${Contest_id}/${f.name}`,
           }));
           if (editingNotice && editingNotice.files !== JSON.stringify(files)) {
             message.info("请先移除新上传的文件");

--- a/src/pages/InfoSite/MentorApplicationPage.tsx
+++ b/src/pages/InfoSite/MentorApplicationPage.tsx
@@ -888,7 +888,7 @@ const MentorApplicationPage = () => {
   const handleUploadRecord = async (e: RcCustomRequestOptions, application_id: any) => {
     try{
       const url = `chat_record/${application_id}/${e.file.name}`;
-      const result = await uploadFile(e.file, url, "chat_record", {application_id: application_id});
+      const result = await uploadFile(e.file, url);
       e.onSuccess(result, e.file);
       handleApplicationChatStatusChange(true, application_id);
     } catch(err) {
@@ -907,12 +907,12 @@ const MentorApplicationPage = () => {
 
   const handleDownloadRecord = async (application_id: any) => {
     try{
-      const fileList = await listFile(`chat_record/${application_id}/`, "chat_record", {application_id: application_id});
+      const fileList = await listFile(`chat_record/${application_id}/`);
       const url = fileList.reduce((max, item) => {
           return new Date(item.LastModified) > new Date(max.LastModified) ? item : max;
       }).Key;
       message.info("开始下载");
-      downloadFile(url, "chat_record", {application_id: application_id});
+      downloadFile(url);
     } catch (err) {
       console.log(err);
       message.error(`下载失败`);
@@ -978,7 +978,7 @@ const MentorApplicationPage = () => {
                   </Descriptions.Item>
                   <Descriptions.Item label="申请状态">
                     {item.status === "submitted" ? (
-                      <Badge status="processing" text="已提交" />
+                      <Badge status="processing" text="待处理" />
                     ) : item.status === "approved" ? (
                       <Badge status="success" text="已通过" />
                     ) : (
@@ -1126,7 +1126,7 @@ const MentorApplicationPage = () => {
                   </Descriptions.Item>
                   <Descriptions.Item label="申请状态">
                     {item.status === "submitted" ? (
-                      <Badge status="processing" text="已提交" />
+                      <Badge status="processing" text="待处理" />
                     ) : item.status === "approved" ? (
                       <Badge status="success" text="已通过" />
                     ) : (


### PR DESCRIPTION
重新整理了一下COS访问路径。
优化了前端体验，只需要传输url就行，后端从url里提取参数。
根据contest_id分离了比赛存储，为长期维护做准备。