### PR TITLE
fix: Using target=_blank without rel=noreferrer (which implies rel=no…

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Development: https://api-dev.eesast.com
 # Development with localhost: http://localhost:28888
 REACT_APP_API_URL=https://api.eesast.com
-REACT_APP_API_DEV_URL=http://localhost:28888
+REACT_APP_API_DEV_URL=https://api-dev.eesast.com
 
 # Static resources like pictures in COS
 REACT_APP_STATIC_URL=https://static.eesast.com

--- a/src/app/ContestSite/IntroPage.tsx
+++ b/src/app/ContestSite/IntroPage.tsx
@@ -136,7 +136,11 @@ const IntroPage: React.FC<ContestProps> = ({ mode, user }) => {
                       <p style={{ color: isPastEvent ? "grey" : "inherit" }}>
                         {index === contestTimes.length - 1
                           ? contestTime.description && (
-                              <a href={contestTime.description} target="_blank">
+                              <a
+                                href={contestTime.description}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
                                 {contestTime.description}
                               </a>
                             )


### PR DESCRIPTION
…opener) is a security risk in older browsers